### PR TITLE
fix(reference alias): Properly support PackageReference Alias (#3070)

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpCompilingProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpCompilingProcessTests.cs
@@ -72,11 +72,11 @@ public class Calculator
     }
 
     [TestMethod]
-    public void CompilingProcessTests_ShouldSupportReferenceAliases()
+    public void CompilingProcessTests_ShouldSupportPackageReferenceAliases()
     {
         var syntaxTree = CSharpSyntaxTree.ParseText(@"
-extern alias Texte;
-using System;
+extern alias TestAlias;
+using TestAlias::System;
 
 namespace ExampleProject
 {
@@ -97,15 +97,30 @@ public class Calculator
                     properties: new Dictionary<string, string>()
                     {
                         { "TargetDir", "" },
-                        { "AssemblyName", "AssemblyName"},
-                        { "TargetFileName", "TargetFileName.dll"},
+                        { "AssemblyName", "AssemblyName" },
+                        { "TargetFileName", "TargetFileName.dll" },
                     },
                     // add a reference to system so the example code can compile
-                    references: new[] { typeof(object).Assembly.Location, $"Texte={typeof(StringBuilder).Assembly.Location}" }
+                    references: new[] { typeof(object).Assembly.Location },
+                    packageReferences: new ReadOnlyDictionary<string, IReadOnlyDictionary<string, string>>(
+                         new Dictionary<string, IReadOnlyDictionary<string, string>>
+                         {
+                             {
+                                 typeof(object).Assembly.GetName().Name,
+                                 new ReadOnlyDictionary<string, string>(
+                                     new Dictionary<string, string>
+                                     {
+                                         { "Aliases", "TestAlias" }
+                                     }
+                                 )
+                             }
+                         }
+                    )
                 ).Object
             }
         };
         var rollbackProcessMock = new Mock<ICSharpRollbackProcess>(MockBehavior.Strict);
+
 
         var target = new CsharpCompilingProcess(input, rollbackProcessMock.Object);
 

--- a/src/Stryker.Core/Stryker.Core/Initialisation/Buildalyzer/IAnalyzerResultExtensions.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/Buildalyzer/IAnalyzerResultExtensions.cs
@@ -107,15 +107,26 @@ public static class IAnalyzerResultExtensions
     {
         foreach (var reference in analyzerResult.References)
         {
-            if (reference.Contains('='))
+            var referenceFileNameWithoutExtension = Path.GetFileNameWithoutExtension(reference);
+            string packageWithAlias = null;
+
+            if (analyzerResult.PackageReferences is not null)
             {
-                // we have an alias
-                var split = reference.Split('=');
-                var aliases = split[0].Split(',');
-                yield return MetadataReference.CreateFromFile(split[1]).WithAliases(aliases);
+                // Check for any matching package reference with an alias using LINQ
+                packageWithAlias = analyzerResult.PackageReferences
+                    .Where(pr => pr.Key == referenceFileNameWithoutExtension && pr.Value.ContainsKey("Aliases"))
+                    .Select(pr => pr.Value["Aliases"])
+                    .FirstOrDefault();
+            }
+                
+            if (packageWithAlias is not null)
+            {
+                // Return the reference with the alias
+                yield return MetadataReference.CreateFromFile(reference).WithAliases(new[] { packageWithAlias });
             }
             else
             {
+                // If no alias is found, return the reference without aliases
                 yield return MetadataReference.CreateFromFile(reference);
             }
         }


### PR DESCRIPTION
* Fix Package Reference Alias and updated tests

* Update src/Stryker.Core/Stryker.Core/Initialisation/Buildalyzer/IAnalyzerResultExtensions.cs

---------